### PR TITLE
Alle strtolower entfernt, da sie das UTF-8 kaputt machen und dadurch …

### DIFF
--- a/IPS2TankerkoenigConfigurator/module.php
+++ b/IPS2TankerkoenigConfigurator/module.php
@@ -112,10 +112,10 @@
 				
 				$i = 0;
 				foreach($ResultArray->stations as $Stations) {
-					$StationArray[$i]["Brand"] = ucwords(strtolower($Stations->brand));
-					$StationArray[$i]["Name"] = ucwords(strtolower($Stations->name));
-					$StationArray[$i]["Street"] = ucwords(strtolower($Stations->street));
-					$StationArray[$i]["Place"] = ucwords(strtolower($Stations->place));
+					$StationArray[$i]["Brand"] = $Stations->brand;
+					$StationArray[$i]["Name"] = $Stations->name;
+					$StationArray[$i]["Street"] = $Stations->street;
+					$StationArray[$i]["Place"] = $Stations->place;
 					$StationArray[$i]["StationsID"] = $Stations->id;
 					$StationArray[$i]["InstanceID"] = $this->GetStationInstanceID($Stations->id);
 

--- a/IPS2TankerkoenigListe/module.php
+++ b/IPS2TankerkoenigListe/module.php
@@ -274,10 +274,10 @@
 			If ($this->ReadPropertyBoolean("ShowOnlyOpen") == false) {
 				$table .= '<tr>';
 				If ($this->ReadPropertyBoolean("Brand") == true) { 
-					$table .= '<td class="tg-611x">'.ucwords(strtolower($Stations->brand)).'</td>';
+					$table .= '<td class="tg-611x">'.$Stations->brand.'</td>';
 				}
-				$table .= '<td class="tg-611x">'.ucwords(strtolower($Stations->name)).'</td>';
-				$table .= '<td class="tg-611x">'.ucwords(strtolower($Stations->place)).'</td>';
+				$table .= '<td class="tg-611x">'.$Stations->name.'</td>';
+				$table .= '<td class="tg-611x">'.$Stations->place.'</td>';
 				If ($this->ReadPropertyBoolean("Diesel") == true) {
 					If (floatval($Stations->diesel) == $Diesel) {
 						$table .= $Font.'<font color='.$ColorCode.'>'.$Stations->diesel.'</font> </td>';
@@ -317,10 +317,10 @@
 				If ($Stations->isOpen == true) {
 					$table .= '<tr>';
 					If ($this->ReadPropertyBoolean("Brand") == true) { 
-						$table .= '<td class="tg-611x">'.ucwords(strtolower($Stations->brand)).'</td>';
+						$table .= '<td class="tg-611x">'.$Stations->brand.'</td>';
 					}
-					$table .= '<td class="tg-611x">'.ucwords(strtolower($Stations->name)).'</td>';
-					$table .= '<td class="tg-611x">'.ucwords(strtolower($Stations->place)).'</td>';
+					$table .= '<td class="tg-611x">'.$Stations->name.'</td>';
+					$table .= '<td class="tg-611x">'.$Stations->place.'</td>';
 					If ($this->ReadPropertyBoolean("Diesel") == true) {
 						If (floatval($Stations->diesel) == $Diesel) {
 							$table .= $Font.'<font color='.$ColorCode.'>'.$Stations->diesel.'</font> </td>';
@@ -407,16 +407,16 @@
 		$table .= "</style>";
 		$table .= '<table class="tg">';
 		$table .= '<tr>';
-		$table .= '<td class="tg-611x">'.ucwords(strtolower($ResultArray->station->brand)).'</td>';
+		$table .= '<td class="tg-611x">'.$ResultArray->station->brand.'</td>';
 		$table .= '</tr>';
 		$table .= '<tr>';
-		$table .= '<td class="tg-611x">'.ucwords(strtolower($ResultArray->station->name)).'</td>';
+		$table .= '<td class="tg-611x">'.$ResultArray->station->name.'</td>';
 		$table .= '</tr>';
 		$table .= '<tr>';
-		$table .= '<td class="tg-611x">'.ucwords(strtolower($ResultArray->station->street))." ".$ResultArray->station->houseNumber.'</td>';
+		$table .= '<td class="tg-611x">'.$ResultArray->station->street." ".$ResultArray->station->houseNumber.'</td>';
 		$table .= '</tr>';
 		$table .= '<tr>';
-		$table .= '<td class="tg-611x">'.$ResultArray->station->postCode." ".ucwords(strtolower($ResultArray->station->place)).'</td>';
+		$table .= '<td class="tg-611x">'.$ResultArray->station->postCode." ".$ResultArray->station->place.'</td>';
 		$table .= '</tr>';
 		If (boolval($ResultArray->station->wholeDay) == true) {
 			$table .= '<tr>';

--- a/IPS2TankerkoenigStation/module.php
+++ b/IPS2TankerkoenigStation/module.php
@@ -196,16 +196,16 @@
 		$table .= "</style>";
 		$table .= '<table class="tg">';
 		$table .= '<tr>';
-		$table .= '<td class="tg-611x">'.ucwords(strtolower($ResultArray->station->brand)).'</td>';
+		$table .= '<td class="tg-611x">'.$ResultArray->station->brand.'</td>';
 		$table .= '</tr>';
 		$table .= '<tr>';
-		$table .= '<td class="tg-611x">'.ucwords(strtolower($ResultArray->station->name)).'</td>';
+		$table .= '<td class="tg-611x">'.$ResultArray->station->name.'</td>';
 		$table .= '</tr>';
 		$table .= '<tr>';
-		$table .= '<td class="tg-611x">'.ucwords(strtolower($ResultArray->station->street))." ".$ResultArray->station->houseNumber.'</td>';
+		$table .= '<td class="tg-611x">'.$ResultArray->station->street." ".$ResultArray->station->houseNumber.'</td>';
 		$table .= '</tr>';
 		$table .= '<tr>';
-		$table .= '<td class="tg-611x">'.$ResultArray->station->postCode." ".ucwords(strtolower($ResultArray->station->place)).'</td>';
+		$table .= '<td class="tg-611x">'.$ResultArray->station->postCode." ".$ResultArray->station->place.'</td>';
 		$table .= '</tr>';
 		If (boolval($ResultArray->station->wholeDay) == true) {
 			$table .= '<tr>';


### PR DESCRIPTION
…sowohl das JSON des Konfigurator nicht mehr lädt, als auch Fehlerhafte Darstellung im WebFront.

Ist ist m.M. auch sinnvoller die falschen Daten an Tankerkönig zurückzumelden, anstatt mit ucwords & strlower Marken, Straßen und Städtenamen falsch darzustellen.